### PR TITLE
chore: Increase coverage for System.Text.Json integration

### DIFF
--- a/src/YamlDotNet.System.Text.Json.Tests/BuilderExtensionsTests.cs
+++ b/src/YamlDotNet.System.Text.Json.Tests/BuilderExtensionsTests.cs
@@ -1,0 +1,49 @@
+using YamlDotNet.Serialization;
+
+namespace YamlDotNet.System.Text.Json.Tests;
+
+public class BuilderExtensionsTests
+{
+    [Fact]
+    public void AddSystemTextJson_OnSerializerBuilder_ReturnsSameInstance()
+    {
+        var builder = new SerializerBuilder();
+
+        var result = builder.AddSystemTextJson();
+
+        result.ShouldBeSameAs(builder);
+
+        var serializer = result.Build();
+        serializer.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AddSystemTextJson_OnDeserializerBuilder_ReturnsSameInstance()
+    {
+        var builder = new DeserializerBuilder();
+
+        var result = builder.AddSystemTextJson();
+
+        result.ShouldBeSameAs(builder);
+
+        var deserializer = result.Build();
+        deserializer.ShouldNotBeNull();
+    }
+
+    [Fact]
+    public void AddSystemTextJson_SerializerBuilderNull_ThrowsArgumentNullException()
+    {
+        var exception = Should.Throw<ArgumentNullException>(() => BuilderExtensions.AddSystemTextJson((SerializerBuilder)null!));
+
+        exception.ParamName.ShouldBe("builder");
+    }
+
+    [Fact]
+    public void AddSystemTextJson_DeserializerBuilderNull_ThrowsArgumentNullException()
+    {
+        var exception = Should.Throw<ArgumentNullException>(() => BuilderExtensions.AddSystemTextJson((DeserializerBuilder)null!));
+
+        exception.ParamName.ShouldBe("builder");
+    }
+
+}

--- a/src/YamlDotNet.System.Text.Json.Tests/ExtensionDataPropertyDescriptorTests.cs
+++ b/src/YamlDotNet.System.Text.Json.Tests/ExtensionDataPropertyDescriptorTests.cs
@@ -1,0 +1,107 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Text.Json;
+using Shouldly;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+
+namespace YamlDotNet.System.Text.Json.Tests;
+
+public class ExtensionDataPropertyDescriptorTests
+{
+    [Fact]
+    public void PropertiesExposeMutableState()
+    {
+        var baseDescriptor = new TestPropertyDescriptor("ExtensionData", typeof(IDictionary<string, JsonElement>));
+        var descriptor = new ExtensionDataPropertyDescriptor(baseDescriptor);
+
+        descriptor.AllowNulls = true;
+        descriptor.TypeOverride = typeof(int);
+        descriptor.ConverterType = typeof(string);
+        descriptor.Order = 7;
+        descriptor.ScalarStyle = ScalarStyle.DoubleQuoted;
+        descriptor.CanWrite = true;
+
+        descriptor.AllowNulls.ShouldBeTrue();
+        descriptor.Name.ShouldBe("ExtensionData");
+        descriptor.Required.ShouldBeFalse();
+        descriptor.Type.ShouldBe(typeof(object));
+        descriptor.TypeOverride.ShouldBe(typeof(int));
+        descriptor.ConverterType.ShouldBe(typeof(string));
+        descriptor.Order.ShouldBe(7);
+        descriptor.ScalarStyle.ShouldBe(ScalarStyle.DoubleQuoted);
+        descriptor.CanWrite.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void WriteSerializesJsonElementValues()
+    {
+        var baseDescriptor = new TestPropertyDescriptor("ExtensionData", typeof(Dictionary<string, JsonElement>));
+        var descriptor = new ExtensionDataPropertyDescriptor(baseDescriptor);
+
+        var target = new object();
+
+        descriptor.Write(target, "value");
+
+        var stored = (IDictionary<string, JsonElement>)baseDescriptor.Read(target).Value!;
+        stored.ShouldContainKey("ExtensionData");
+        stored["ExtensionData"].ValueKind.ShouldBe(JsonValueKind.String);
+        stored["ExtensionData"].GetString().ShouldBe("value");
+
+        var roundTrip = descriptor.Read(target);
+        roundTrip.Value.ShouldBe(stored["ExtensionData"]);
+    }
+
+    [Fact]
+    public void WriteCreatesDictionaryForObjectInterface()
+    {
+        var baseDescriptor = new TestPropertyDescriptor("ExtensionData", typeof(IDictionary<string, object>));
+        var descriptor = new ExtensionDataPropertyDescriptor(baseDescriptor);
+
+        var target = new object();
+
+        descriptor.Write(target, 42);
+
+        var stored = (IDictionary<string, object>)baseDescriptor.Read(target).Value!;
+        stored.ShouldContainKey("ExtensionData");
+        stored["ExtensionData"].ShouldBe(42);
+    }
+
+    [Fact]
+    public void WriteCreatesDictionaryForJsonElementInterface()
+    {
+        var baseDescriptor = new TestPropertyDescriptor("ExtensionData", typeof(IDictionary<string, JsonElement>));
+        var descriptor = new ExtensionDataPropertyDescriptor(baseDescriptor);
+
+        var target = new object();
+
+        descriptor.Write(target, "payload");
+
+        var stored = (IDictionary<string, JsonElement>)baseDescriptor.Read(target).Value!;
+        stored.ShouldContainKey("ExtensionData");
+        stored["ExtensionData"].GetString().ShouldBe("payload");
+    }
+
+    [Fact]
+    public void WriteThrowsForUnsupportedDictionaryValueType()
+    {
+        var baseDescriptor = new TestPropertyDescriptor("ExtensionData", typeof(Dictionary<string, int>));
+        var descriptor = new ExtensionDataPropertyDescriptor(baseDescriptor);
+
+        var target = new object();
+
+        Should.Throw<InvalidOperationException>(() => descriptor.Write(target, 5));
+    }
+
+    [Fact]
+    public void WriteThrowsWhenTypeIsNotDictionary()
+    {
+        var baseDescriptor = new TestPropertyDescriptor("ExtensionData", typeof(string));
+        var descriptor = new ExtensionDataPropertyDescriptor(baseDescriptor);
+
+        var target = new object();
+
+        Should.Throw<InvalidOperationException>(() => descriptor.Write(target, "value"));
+    }
+
+}

--- a/src/YamlDotNet.System.Text.Json.Tests/SystemTextJsonTypeInspectorTests.cs
+++ b/src/YamlDotNet.System.Text.Json.Tests/SystemTextJsonTypeInspectorTests.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Shouldly;
+using YamlDotNet.Serialization;
+
+namespace YamlDotNet.System.Text.Json.Tests;
+
+public class SystemTextJsonTypeInspectorTests
+{
+    [Fact]
+    public void GetProperty_UsesCaseInsensitiveMatching()
+    {
+        var descriptors = new[]
+        {
+            new TestPropertyDescriptor("ActualName", typeof(string))
+        };
+
+        var inspector = new SystemTextJsonTypeInspector(new StubTypeInspector(descriptors));
+
+        var result = inspector.GetProperty(typeof(object), null, "actualname", ignoreUnmatched: true, caseInsensitivePropertyMatching: true);
+
+        result.ShouldNotBeNull();
+        result.Name.ShouldBe("ActualName");
+    }
+
+    [Fact]
+    public void GetProperty_ReturnsExtensionDescriptorWhenMissing()
+    {
+        var container = new ContainerWithExtensionData();
+        container.ExtensionData["dynamic"] = JsonSerializer.SerializeToElement("value");
+
+        var attributes = new Attribute[] { new JsonExtensionDataAttribute() };
+        var extensionDescriptor = new TestPropertyDescriptor(
+            "ExtensionData",
+            typeof(Dictionary<string, JsonElement>),
+            reader: _ => container.ExtensionData,
+            writer: (_, value) =>
+            {
+                if (value is IDictionary<string, JsonElement> dict)
+                {
+                    container.ExtensionData = dict;
+                }
+            },
+            attributes: attributes);
+
+        var inspector = new SystemTextJsonTypeInspector(new StubTypeInspector(new[] { extensionDescriptor }));
+
+        var result = inspector.GetProperty(typeof(ContainerWithExtensionData), container, "newKey", ignoreUnmatched: true, caseInsensitivePropertyMatching: false);
+
+        result.ShouldBeOfType<ExtensionDataPropertyDescriptor>();
+        result.Name.ShouldBe("newKey");
+    }
+
+    [Fact]
+    public void GetProperty_ThrowsWhenMultipleMatches()
+    {
+        var descriptors = new[]
+        {
+            new TestPropertyDescriptor("Duplicate", typeof(string)),
+            new TestPropertyDescriptor("Duplicate", typeof(string))
+        };
+
+        var inspector = new SystemTextJsonTypeInspector(new StubTypeInspector(descriptors));
+
+        Should.Throw<SerializationException>(() => inspector.GetProperty(typeof(object), null, "Duplicate", ignoreUnmatched: true, caseInsensitivePropertyMatching: false));
+    }
+
+    private sealed class StubTypeInspector : ITypeInspector
+    {
+        private readonly IReadOnlyList<IPropertyDescriptor> _properties;
+
+        public StubTypeInspector(IReadOnlyList<IPropertyDescriptor> properties)
+        {
+            _properties = properties;
+        }
+
+        public string GetEnumName(Type enumType, string name) => name;
+
+        public string GetEnumValue(object enumValue) => enumValue.ToString()!;
+
+        public IEnumerable<IPropertyDescriptor> GetProperties(Type type, object? container) => _properties;
+
+        public IPropertyDescriptor GetProperty(Type type, object? container, string name, bool ignoreUnmatched, bool caseInsensitivePropertyMatching)
+        {
+            if (caseInsensitivePropertyMatching)
+            {
+                return _properties.First(p => p.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+            }
+
+            return _properties.First(p => p.Name == name);
+        }
+    }
+
+    private sealed class ContainerWithExtensionData
+    {
+        public IDictionary<string, JsonElement> ExtensionData { get; set; } = new Dictionary<string, JsonElement>();
+    }
+}

--- a/src/YamlDotNet.System.Text.Json.Tests/SystemTextJsonYamlTypeConverterCoverageTests.cs
+++ b/src/YamlDotNet.System.Text.Json.Tests/SystemTextJsonYamlTypeConverterCoverageTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Shouldly;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+using YamlDotNet.System.Text.Json;
+
+namespace YamlDotNet.System.Text.Json.Tests;
+
+public class SystemTextJsonYamlTypeConverterCoverageTests
+{
+    private static readonly ObjectDeserializer RootDeserializer = _ => null;
+    private static readonly ObjectSerializer StubSerializer = (_, _) => { };
+
+    [Fact]
+    public void ReadYaml_ReturnsNullForUnsupportedType()
+    {
+        var converter = new SystemTextJsonYamlTypeConverter();
+        var parser = CreateParser("value");
+
+        var result = converter.ReadYaml(parser, typeof(Guid), RootDeserializer);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ReadYaml_ReturnsNullForJsonObjectWhenScalarProvided()
+    {
+        var converter = new SystemTextJsonYamlTypeConverter();
+        var parser = CreateParser("scalar");
+
+        var result = converter.ReadYaml(parser, typeof(JsonObject), RootDeserializer);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ReadYaml_ReturnsNullForJsonNodeWhenEmpty()
+    {
+        var converter = new SystemTextJsonYamlTypeConverter();
+        var parser = CreateParser(string.Empty);
+
+        var result = converter.ReadYaml(parser, typeof(JsonNode), RootDeserializer);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void ReadYaml_ReturnsNullForJsonDocumentWhenEmpty()
+    {
+        var converter = new SystemTextJsonYamlTypeConverter();
+        var parser = CreateParser(string.Empty);
+
+        var result = converter.ReadYaml(parser, typeof(JsonDocument), RootDeserializer);
+
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public void WriteYaml_HandlesJsonNodeValues()
+    {
+        var converter = new SystemTextJsonYamlTypeConverter();
+        var emitter = new RecordingEmitter();
+
+        converter.WriteYaml(emitter, JsonNode.Parse("{\"name\":1}")!, typeof(JsonNode), StubSerializer);
+        converter.WriteYaml(emitter, JsonNode.Parse("[1,2]")!, typeof(JsonNode), StubSerializer);
+        converter.WriteYaml(emitter, JsonNode.Parse("\"text\"")!, typeof(JsonNode), StubSerializer);
+
+        emitter.Events.OfType<MappingStart>().ShouldNotBeEmpty();
+        emitter.Events.OfType<SequenceStart>().ShouldNotBeEmpty();
+        emitter.Events.OfType<Scalar>().Any(s => s.Value == "text").ShouldBeTrue();
+    }
+
+    [Fact]
+    public void WriteYaml_HandlesJsonElementKinds()
+    {
+        var converter = new SystemTextJsonYamlTypeConverter();
+        var emitter = new RecordingEmitter();
+
+        using var objectDoc = JsonDocument.Parse("{\"value\":1}");
+        converter.WriteYaml(emitter, objectDoc.RootElement, typeof(JsonElement), StubSerializer);
+
+        using var arrayDoc = JsonDocument.Parse("[1,2]");
+        converter.WriteYaml(emitter, arrayDoc.RootElement, typeof(JsonElement), StubSerializer);
+
+        using var stringDoc = JsonDocument.Parse("\"value\"");
+        converter.WriteYaml(emitter, stringDoc.RootElement, typeof(JsonElement), StubSerializer);
+
+        converter.WriteYaml(emitter, default(JsonElement), typeof(JsonElement), StubSerializer);
+
+        emitter.Events.OfType<Scalar>().ShouldNotBeEmpty();
+    }
+
+    [Fact]
+    public void WriteYaml_HandlesJsonValueKinds()
+    {
+        var converter = new SystemTextJsonYamlTypeConverter();
+        var emitter = new RecordingEmitter();
+
+        var stringValue = JsonValue.Create("value")!;
+        converter.WriteYaml(emitter, stringValue, typeof(JsonValue), StubSerializer);
+
+        var numberValue = JsonValue.Create(3.14)!;
+        converter.WriteYaml(emitter, numberValue, typeof(JsonValue), StubSerializer);
+
+        var boolValue = JsonValue.Create(true)!;
+        converter.WriteYaml(emitter, boolValue, typeof(JsonValue), StubSerializer);
+
+        var nullValue = JsonValue.Create((string?)null)!;
+        converter.WriteYaml(emitter, nullValue, typeof(JsonValue), StubSerializer);
+
+        var undefinedValue = (JsonValue)JsonValue.Create(default(JsonElement))!;
+        converter.WriteYaml(emitter, undefinedValue, typeof(JsonValue), StubSerializer);
+
+        emitter.Events.Count.ShouldBeGreaterThan(0);
+    }
+
+    private static Parser CreateParser(string yaml)
+    {
+        var reader = new Parser(new StringReader(yaml ?? string.Empty));
+        return reader;
+    }
+
+    private sealed class RecordingEmitter : IEmitter
+    {
+        public IList<ParsingEvent> Events { get; } = new List<ParsingEvent>();
+
+        public void Emit(ParsingEvent @event)
+        {
+            Events.Add(@event);
+        }
+    }
+}

--- a/src/YamlDotNet.System.Text.Json.Tests/TestPropertyDescriptor.cs
+++ b/src/YamlDotNet.System.Text.Json.Tests/TestPropertyDescriptor.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+
+namespace YamlDotNet.System.Text.Json.Tests;
+
+internal sealed class TestPropertyDescriptor : IPropertyDescriptor
+{
+    private readonly IReadOnlyList<Attribute> _attributes;
+    private readonly Func<object?, object?>? _reader;
+    private readonly Action<object?, object?>? _writer;
+    private object? _value;
+
+    public TestPropertyDescriptor(
+        string name,
+        Type type,
+        object? initialValue = null,
+        IEnumerable<Attribute>? attributes = null,
+        Func<object?, object?>? reader = null,
+        Action<object?, object?>? writer = null)
+    {
+        Name = name;
+        Type = type;
+        _value = initialValue;
+        _attributes = attributes?.ToArray() ?? Array.Empty<Attribute>();
+        _reader = reader;
+        _writer = writer;
+    }
+
+    public bool AllowNulls { get; set; }
+
+    public string Name { get; set; }
+
+    public bool Required => false;
+
+    public Type Type { get; }
+
+    public Type? TypeOverride { get; set; }
+
+    public Type? ConverterType { get; set; }
+
+    public int Order { get; set; }
+
+    public ScalarStyle ScalarStyle { get; set; }
+
+    public bool CanWrite { get; set; }
+
+    public void Write(object? target, object? value)
+    {
+        _value = value;
+        _writer?.Invoke(target, value);
+    }
+
+    public T? GetCustomAttribute<T>() where T : Attribute
+    {
+        foreach (var attribute in _attributes)
+        {
+            if (attribute is T typed)
+            {
+                return typed;
+            }
+        }
+
+        return default;
+    }
+
+    public IObjectDescriptor Read(object? target)
+    {
+        var value = _reader?.Invoke(target) ?? _value;
+        var type = value?.GetType() ?? typeof(object);
+        return new ObjectDescriptor(value, type, type);
+    }
+}

--- a/src/YamlDotNet.System.Text.Json/AssemblyInfo.cs
+++ b/src/YamlDotNet.System.Text.Json/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("YamlDotNet.System.Text.Json.Tests")]


### PR DESCRIPTION
## Summary
- add builder extension tests covering fluent configuration and null guard paths
- exercise extension data descriptor dictionary handling and invalid type scenarios via targeted tests
- cover type inspector fallbacks and SystemTextJsonYamlTypeConverter read/write branches
- expose internals to the test assembly for exercising internal helpers

## Testing
- dotnet test
- dotnet-coverage collect 'dotnet test' -f cobertura -o coverage/coverage.xml

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691194be1a40832693df2ac289f5cf1b)